### PR TITLE
core/engine: fix api and query_cache by MySQL8

### DIFF
--- a/storage/tianmu/core/engine.cpp
+++ b/storage/tianmu/core/engine.cpp
@@ -1342,7 +1342,7 @@ void Engine::LogStat() {
         SQLCOM_LOAD,
     };
 
-    STATUS_VAR sv;
+  System_status_var sv; // stonedb8
 	mysql_mutex_lock(&LOCK_status);
     calc_sum_of_all_status(&sv);
 	mysql_mutex_unlock(&LOCK_status);
@@ -1491,7 +1491,7 @@ common::TIANMUError Engine::RunLoader(THD *thd, sql_exchange *ex, TABLE_LIST *ta
 
     // We must invalidate the table in query cache before binlog writing and
     // ha_autocommit_...
-    query_cache.invalidate(thd, table_list, 0);
+    //query_cache.invalidate(thd, table_list, 0);  // stonedb 8 TODO: query_cache is deleted by MySQL8
 
     COPY_INFO::Statistics stats;
     stats.records = ha_rows(tab->NoRecordsLoaded());
@@ -1500,7 +1500,7 @@ common::TIANMUError Engine::RunLoader(THD *thd, sql_exchange *ex, TABLE_LIST *ta
     tianmu_stat.load_cnt++;
 
     char name[FN_REFLEN];
-    my_snprintf(name, sizeof(name), ER(ER_LOAD_INFO), (long)stats.records,
+    snprintf(name, sizeof(name), ER(ER_LOAD_INFO), (long)stats.records,
                 0,  // deleted
                 0,  // skipped
                 (long)thd->get_stmt_da()->current_statement_cond_count());

--- a/storage/tianmu/core/engine_execute.cpp
+++ b/storage/tianmu/core/engine_execute.cpp
@@ -102,7 +102,7 @@ int Engine::HandleSelect(THD *thd, LEX *lex, Query_result *&result, ulong setup_
     Only register query in cache if it tables were locked above.
     Tables must be locked before storing the query in the query cache.
   */
-  query_cache.store_query(thd, thd->lex->query_tables);
+  //query_cache.store_query(thd, thd->lex->query_tables);   // stonedb 8 TODO: query_cache is deleted by MySQL8
 
   tianmu_stat.select++;
 

--- a/storage/tianmu/handler/tianmu_handler_com.cpp
+++ b/storage/tianmu/handler/tianmu_handler_com.cpp
@@ -216,7 +216,7 @@ int rcbase_init_func(void *p) {
     struct hostent *hent = NULL;
     hent = gethostbyname(glob_hostname);
     if (hent) strmov_str(global_hostIP_, inet_ntoa(*(struct in_addr *)(hent->h_addr_list[0])));
-    my_snprintf(global_serverinfo_, sizeof(global_serverinfo_), "\tServerIp:%s\tServerHostName:%s\tServerPort:%d",
+    snprintf(global_serverinfo_, sizeof(global_serverinfo_), "\tServerIp:%s\tServerHostName:%s\tServerPort:%d",
                 global_hostIP_, glob_hostname, mysqld_port);
     ha_kvstore_ = new index::KVStore();
     ha_kvstore_->Init();


### PR DESCRIPTION
	query_cache is deleted by MySQL8
	my_snprintf change to snprintf
	STATUS_VAR change to System_status_var