### PR TITLE
fix: struct Field、TABLE modify by MySQL8

### DIFF
--- a/storage/tianmu/handler/tianmu_handler.cpp
+++ b/storage/tianmu/handler/tianmu_handler.cpp
@@ -296,7 +296,7 @@ inline bool has_dup_key(std::shared_ptr<index::RCTableIndex> &indextab, TABLE *t
   KEY *key = table->key_info + table->s->primary_key;
 
   for (uint i = 0; i < key->actual_key_parts; i++) {
-    uint col = key->key_part[i].field->field_index;
+    uint col = key->key_part[i].field->field_index();
     Field *f = table->field[col];
     switch (f->type()) {
       case MYSQL_TYPE_TINY:

--- a/storage/tianmu/index/rc_table_index.cpp
+++ b/storage/tianmu/index/rc_table_index.cpp
@@ -57,7 +57,7 @@ void create_rdbkey(TABLE *table, uint i, std::shared_ptr<RdbKey> &new_key_def, r
         unsigned_flag = false;
         break;
     }
-    vcols.emplace_back(ColAttr{key_info->key_part[n].field->field_index, f->type(), unsigned_flag});
+    vcols.emplace_back(ColAttr{key_info->key_part[n].field->field_index(), f->type(), unsigned_flag});
   }
 
   const char *const key_name = table->key_info[i].name;
@@ -109,7 +109,7 @@ RCTableIndex::RCTableIndex(const std::string &name, TABLE *table) {
   rdbkey_ = tbl_->m_rdbkeys[pk_index(table, tbl_)];
   // compatible version that primary key make up of one part
   if (table->key_info[keyid_].actual_key_parts == 1)
-    cols_.push_back(table->key_info[keyid_].key_part[0].field->field_index);
+    cols_.push_back(table->key_info[keyid_].key_part[0].field->field_index());
   else
     rdbkey_->get_key_cols(cols_);
   enable_ = true;

--- a/storage/tianmu/types/rc_item_types.h
+++ b/storage/tianmu/types/rc_item_types.h
@@ -41,11 +41,14 @@ class Item_sum_int_rcbase : public Item_sum_num {
   enum Sumfunctype sum_func() const override { return COUNT_FUNC; }
   enum Item_result result_type() const override { return INT_RESULT; }
 
+  // stonedb8 mysql8 delete fix_length_and_dec(), and this func is not called
+  /*
   void fix_length_and_dec() override {
     decimals = 0;
     max_length = 21;
     maybe_null = null_value = 0;
   }
+  */
 
   void int64_value(int64_t &value_);
 
@@ -99,7 +102,8 @@ public:
 
   enum Sumfunctype sum_func() const override { return MIN_FUNC; }
   enum Item_result result_type() const override { return hybrid_type_; }
-  enum enum_field_types field_type() const override { return hybrid_field_type_; }
+  // stonedb8 mysql8 delete field_type(), and this func is not called
+  //enum enum_field_types field_type() const override { return hybrid_field_type_; } 
 
   bool any_value() { return is_values_; }
   my_decimal *dec_value();


### PR DESCRIPTION
	1.Field: field_index -> field_index()
	2.send_data() parameter change
	3.send_eof() parameter change
	4.TABLE: maybe_null is deleted
	5.fix_length_and_dec() is deleted
	6.field_type() is deleted